### PR TITLE
Rename Base64.base64 encoding table to .standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,5 +13,5 @@
 * [Added] Data.init(hex:)
 * [Added] Base64.decode(data: Data) -> Data
 * [Added] Base64.decode(string: String) -> Data
-* [Added] Base64.base64.encode(data: Data) -> Data
+* [Added] Base64.standard.encode(data: Data) -> Data
 * [Added] Base64.urlSafe.encode(data: Data) -> Data

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features
 
 ```swift
 let data = Data(bytes: [0xc3, 0x98, 0x61, 0x62, 0x63, 0x64])
-let base64encoded = Base64.base64.encode(data: data)
+let base64encoded = Base64.standard.encode(data: data)
 ```
 
 - Base64 (URL and File safe) encode data

--- a/Sources/DataKit/Base64.swift
+++ b/Sources/DataKit/Base64.swift
@@ -7,13 +7,13 @@ import Foundation
 /// Base64 encoder/decoder
 public enum Base64 {
     /// Normal Base64 encoding alphabet as per RFC 4648,4
-    case base64
+    case standard
     /// URL and Filename Safe alphabet as per RFC 4648,5
     case urlSafe
 
     var table: String {
         switch self {
-        case .base64:
+        case .standard:
             return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/="
         case .urlSafe:
             return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_="

--- a/Sources/DataKitBenchmark/main.swift
+++ b/Sources/DataKitBenchmark/main.swift
@@ -63,7 +63,7 @@ func testNSDataBase64Encoding(count: Int = 1000) {
 
     let startTime1: CFTimeInterval = gettime()
     let time1 = dispatch_benchmark(count) {
-        _ = Base64.base64.encode(data: data)
+        _ = Base64.standard.encode(data: data)
     }
     let endTime1: CFTimeInterval = gettime()
 

--- a/Tests/DataKitTests/Base64Tests.swift
+++ b/Tests/DataKitTests/Base64Tests.swift
@@ -244,14 +244,14 @@ final class Base64Tests: XCTestCase {
         let plain = "abcdefghijklmnopqrstuvwxyz0123456789\n".cStringByteBuffer
         let expected = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5Cg==".cStringByteBuffer
 
-        let encoded = Base64.base64.encode(data: plain)
+        let encoded = Base64.standard.encode(data: plain)
         expect(encoded) == expected
     }
 
     func testBase64Encoding_LF() {
         let plain = type(of: self).plainLoremIpsum
         let expected = try! Data(contentsOf: resource(file: "PlainLoremIpsum_76.b64"))//swiftlint:disable:this force_try
-        let encoded = Base64.base64.encode(data: plain, with: .padding, lineFeeds: 76)
+        let encoded = Base64.standard.encode(data: plain, with: .padding, lineFeeds: 76)
 
         expect(encoded) == expected
     }
@@ -261,7 +261,7 @@ final class Base64Tests: XCTestCase {
         //swiftlint:disable:next force_try
         let expected = try! Data(contentsOf: resource(file: "PlainLoremIpsum_76_no_padding.b64"))
 
-        expect(Base64.base64.encode(data: plain, with: .none, lineFeeds: 76)) == expected
+        expect(Base64.standard.encode(data: plain, with: .none, lineFeeds: 76)) == expected
     }
 
     /// Mark: padding


### PR DESCRIPTION
Rename Base64.base64 encoding table to .standard