### PR TITLE
Mfiebig/fix buffer underrun

### DIFF
--- a/Sources/DataKit/Base64.swift
+++ b/Sources/DataKit/Base64.swift
@@ -157,8 +157,10 @@ public enum Base64 {
         let characterTable = self.table.utf8CString
 
         // Pad the last 2 output bytes just in case padding would be needed. If not, the bytes will be overridden later.
-        dataPtr[outlen - 2] = characterTable[0x40]
-        dataPtr[outlen - 1] = characterTable[0x40]
+        if outlen > 2 {
+            dataPtr[outlen - 2] = characterTable[0x40]
+            dataPtr[outlen - 1] = characterTable[0x40]
+        }
 
         // pointer to the input data backing buffer
         _ = data.withUnsafeBytes { (bytesPtr: UnsafeRawBufferPointer) -> Int in

--- a/Tests/DataKitTests/Base64Tests.swift
+++ b/Tests/DataKitTests/Base64Tests.swift
@@ -36,26 +36,16 @@ final class Base64Tests: XCTestCase {
         let base64data = try! Data(contentsOf: resource(file: "asciifull.b64url")) //swiftlint:disable:this force_try
         let expected = try! Data(contentsOf: resource(file: "asciifull.gif")) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: base64data)
-        } == expected
+        expect (try Base64.decode(data: base64data)) == expected
     }
 
     func testURLSafeDecoding_LoremIpsum() {
         let file = resource(file: "PlainLoremIpsum.b64url")
         let data = try! Data(contentsOf: file) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: data)
-        } == type(of: self).plainLoremIpsum
-
-        expect {
-            try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)
-        } == type(of: self).plainLoremIpsum
-
-        expect {
-            try Base64.decode(data: data, mode: .ignoreInvalidCharacters)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data)) == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)) == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreInvalidCharacters)) == type(of: self).plainLoremIpsum
     }
 
     /// Mark: Base64 URL Safe encoding
@@ -82,128 +72,87 @@ final class Base64Tests: XCTestCase {
         let base64 = "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXowMTIzNDU2Nzg5Cg=="
         let plain = "abcdefghijklmnopqrstuvwxyz0123456789\n".cStringByteBuffer
 
-        expect {
-            try Base64.decode(string: base64)
-        } == plain
+        expect(try Base64.decode(string: base64)) == plain
     }
 
     func testBase64DecodingEmpty() {
         let base64 = Data()
 
-        expect {
-            try Base64.decode(data: base64)
-        } == Data()
+        expect(try Base64.decode(data: base64)) == Data()
     }
 
     func testBase64Decoding_image() {
         let base64data = try! Data(contentsOf: resource(file: "asciifull.b64")) //swiftlint:disable:this force_try
         let expected = try! Data(contentsOf: resource(file: "asciifull.gif")) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: base64data)
-        } == expected
+        expect(try Base64.decode(data: base64data)) == expected
     }
 
     func testBase64Decoding_CR_LF() {
         let file = resource(file: "PlainLoremIpsum_CR_LF_76.b64")
         let data = try! Data(contentsOf: file) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: data)
-        }.to(throwError(Base64.Error.invalidBase64String))
+        expect(try Base64.decode(data: data)).to(throwError(Base64.Error.invalidBase64String))
 
-        expect {
-            try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)) == type(of: self).plainLoremIpsum
 
-        expect {
-            try Base64.decode(data: data, mode: .ignoreInvalidCharacters)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreInvalidCharacters)) == type(of: self).plainLoremIpsum
     }
 
     func testBase64Decoding_LF() {
         let file = resource(file: "PlainLoremIpsum_60.b64")
         let data = try! Data(contentsOf: file) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: data)
-        }.to(throwError(Base64.Error.invalidBase64String))
+        expect(try Base64.decode(data: data)).to(throwError(Base64.Error.invalidBase64String))
 
-        expect {
-            try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)) == type(of: self).plainLoremIpsum
 
-        expect {
-            try Base64.decode(data: data, mode: .ignoreInvalidCharacters)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreInvalidCharacters)) == type(of: self).plainLoremIpsum
     }
 
     func testBase64Decoding_LoremIpsum() {
         let file = resource(file: "PlainLoremIpsum.b64")
         let data = try! Data(contentsOf: file) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: data)
-        } == type(of: self).plainLoremIpsum
-
-        expect {
-            try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)
-        } == type(of: self).plainLoremIpsum
-
-        expect {
-            try Base64.decode(data: data, mode: .ignoreInvalidCharacters)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data)) == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)) == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreInvalidCharacters)) == type(of: self).plainLoremIpsum
     }
 
     func testBase64Decoding_LoremIpsum_no_padding() {
         let file = resource(file: "PlainLoremIpsum_76_no_padding.b64")
         let data = try! Data(contentsOf: file) //swiftlint:disable:this force_try
 
-        expect {
-            try Base64.decode(data: data)
-        }.to(throwError(Base64.Error.invalidBase64String))
-
-        expect {
-            try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)
-        } == type(of: self).plainLoremIpsum
-
-        expect {
-            try Base64.decode(data: data, mode: .ignoreInvalidCharacters)
-        } == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data)).to(throwError(Base64.Error.invalidBase64String))
+        expect(try Base64.decode(data: data, mode: .ignoreWhiteSpaceAndNewline)) == type(of: self).plainLoremIpsum
+        expect(try Base64.decode(data: data, mode: .ignoreInvalidCharacters)) == type(of: self).plainLoremIpsum
     }
 
     func testBase64Decoding_illegal_characters() {
         let base64Illegal = "ñYWJjZGVmZ2%hpam.tsbW5vcHFyc3R1\ndnd4eXowMTIzüNDU2Nzg5Cg==".cStringByteBuffer
 
-        expect {
-            try Base64.decode(data: base64Illegal, mode: .failOnInvalidCharacters)
-        }.to(throwError(Base64.Error.invalidBase64String))
+        expect(try Base64.decode(data: base64Illegal, mode: .failOnInvalidCharacters))
+            .to(throwError(Base64.Error.invalidBase64String))
 
-        expect {
-            try Base64.decode(data: base64Illegal, mode: .ignoreWhiteSpaceAndNewline)
-        }.to(throwError(Base64.Error.invalidBase64String))
+        expect(try Base64.decode(data: base64Illegal, mode: .ignoreWhiteSpaceAndNewline))
+            .to(throwError(Base64.Error.invalidBase64String))
 
         let plain = "abcdefghijklmnopqrstuvwxyz0123456789\n".cStringByteBuffer
-        expect {
-            try Base64.decode(data: base64Illegal, mode: .ignoreInvalidCharacters)
-        } == plain
+        expect(try Base64.decode(data: base64Illegal, mode: .ignoreInvalidCharacters)).to(equal(plain))
     }
 
     func testBase64Decoding_illegal_characters_with_early_padding() {
         let base64Illegal = "ñYWJjZGVmZ2%hpam.tsbW5vcHFy=c3R1\ndnd4eXowMTIzüNDU2Nzg5Cg==".cStringByteBuffer
 
-        expect {
-            try Base64.decode(data: base64Illegal, mode: .failOnInvalidCharacters)
-        }.to(throwError(Base64.Error.invalidBase64String))
+        expect (try Base64.decode(data: base64Illegal, mode: .failOnInvalidCharacters))
+            .to(throwError(Base64.Error.invalidBase64String))
 
-        expect {
-            try Base64.decode(data: base64Illegal, mode: .ignoreWhiteSpaceAndNewline)
-        }.to(throwError(Base64.Error.invalidBase64String))
+        expect (try Base64.decode(data: base64Illegal, mode: .ignoreWhiteSpaceAndNewline))
+            .to(throwError(Base64.Error.invalidBase64String))
 
         let plain = "abcdefghijklmnopqr".cStringByteBuffer
-        expect {
-            try Base64.decode(data: base64Illegal, mode: .ignoreInvalidCharacters)
-        } == plain
+        expect (try Base64.decode(data: base64Illegal, mode: .ignoreInvalidCharacters))
+            .to(equal(plain))
     }
 
     func testBase64DecodingLength() {

--- a/Tests/DataKitTests/Base64Tests.swift
+++ b/Tests/DataKitTests/Base64Tests.swift
@@ -58,6 +58,14 @@ final class Base64Tests: XCTestCase {
         expect(encoded) == expected
     }
 
+    func testURLSafeEncodingNoData() {
+        let plain = Data()
+        let expected = Data()
+        let encoded = Base64.urlSafe.encode(data: plain)
+
+        expect(encoded).to(equal(expected))
+    }
+
     func testURLSafeEncoding_padding() {
         let plain = type(of: self).plainLoremIpsum
         //swiftlint:disable:next force_try

--- a/Tests/DataKitTests/DataExtHexStringTests.swift
+++ b/Tests/DataKitTests/DataExtHexStringTests.swift
@@ -23,23 +23,23 @@ final class DataExtHexStringTests: XCTestCase {
     func testHexStringToData() {
         let hexString = "0003f6A0ff"
         let expectedBytes: [UInt8] = [0, 3, 246, 160, 255]
-        expect {
+        expect(
             try Data(hex: hexString)
-        }.to(equal(expectedBytes.data))
+        ).to(equal(expectedBytes.data))
     }
 
     func testHexStringToData_invalid_length() {
         let hexString = "0003f6a0ff0"
-        expect {
+        expect(
             try Data(hex: hexString)
-        }.to(throwError(HexStringParsingError.invalidLength(hexString.count)))
+        ).to(throwError(HexStringParsingError.invalidLength(hexString.count)))
     }
 
     func testNotSoHexStringToData_illegalCharacters() {
         let hexString = "nothex"
-        expect {
+        expect(
             try Data(hex: hexString)
-        }.to(throwError(HexStringParsingError.illegalCharacters(pattern: hexString, index: 0, literal: "no")))
+        ).to(throwError(HexStringParsingError.illegalCharacters(pattern: hexString, index: 0, literal: "no")))
     }
 
     static let allTests = [


### PR DESCRIPTION
I added a test for encoding zero bytes length Data. Running the test with "Guard Malloc" Diagnostics failed the test. Fixed the test accordingly.

<img width="894" alt="Bildschirmfoto 2021-03-30 um 13 40 41" src="https://user-images.githubusercontent.com/2157712/112984509-43c77d80-915f-11eb-95c2-3663435b9b36.png">

Also added some syntax changes to support Xcode 12, might still be broken on other Parts (Nimble through Carthage is broken for Xcode 12)